### PR TITLE
feat: adiciona campo da imagem de capa da unidade

### DIFF
--- a/src/ObjectMapping/Property/Unit.php
+++ b/src/ObjectMapping/Property/Unit.php
@@ -24,6 +24,7 @@ class Unit
     protected ?array $payment_conditions;
     /** @var UnitAdditionalGalleries[] $additional_galleries */
     protected ?array $additional_galleries;
+    protected ?BuildingCover $cover = null;
 
     protected function paymentConditionsItemType(): string
     {
@@ -142,5 +143,10 @@ class Unit
     public function getAdditionalGalleries(): ?array
     {
         return $this->additional_galleries;
+    }
+
+    public function getCover(): ?BuildingCover
+    {
+        return $this->cover;
     }
 }


### PR DESCRIPTION
A nossa querida amiga Dwv, tem vários campos chamados "cover" estava faltando esse que vinha dentro do objeto "unit".